### PR TITLE
fixed dependency not found with locationestimatr

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "random-streetview",
   "version": "1.1.0",
   "description": "Finds a random valid StreetView location in a given polygon.",
-  "main": "src/index.mjs",
+  "main": "src/index.js",
   "scripts": {
   },
   "repository": {


### PR DESCRIPTION
If used in locationestimatr the project couldn't build, because the module wasn't found.
The issue seemed to be the file ending `.mjs` of the modules main script file. Changing it locally in the package.json to `index.js` fixed the issue.
I'm not sure if that's just an issue for me and whether the `.mjs` is on purpose or not.

![grafik](https://user-images.githubusercontent.com/32396733/123561600-aacdf000-d7a9-11eb-837a-439e28277296.png)
